### PR TITLE
don't show 'fe group deny' in page properties

### DIFF
--- a/Configuration/TCA/Overrides/pages.php
+++ b/Configuration/TCA/Overrides/pages.php
@@ -20,5 +20,5 @@ $additionalColumns = array(
     ),
 );
 
-\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addTCAcolumns('pages', $additionalColumns);
-\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addToAllTCAtypes('pages', 'fe_group_deny', '', 'after:fe_group');
+// \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addTCAcolumns('pages', $additionalColumns);
+// \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addToAllTCAtypes('pages', 'fe_group_deny', '', 'after:fe_group');


### PR DESCRIPTION
Since 'deny frontend group' functionality is disabled for pages it shouldn't apear in the page-properties.